### PR TITLE
feat(update-check): override args instead of command

### DIFF
--- a/pkg/resources/update_job.go
+++ b/pkg/resources/update_job.go
@@ -103,9 +103,9 @@ func PrepareMattermostJobTemplate(name, namespace string, baseDeployment *appsv1
 	// Override values for job-specific behavior.
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	for i := range job.Spec.Template.Spec.Containers {
-		if job.Spec.Template.Spec.Containers[i].Name != "mattermost" { continue }
-		
-		job.Spec.Template.Spec.Containers[i].Command = []string{"mattermost", "version"}
+		if job.Spec.Template.Spec.Containers[i].Name == "mattermost" {
+			job.Spec.Template.Spec.Containers[i].Command = []string{"mattermost", "version"}
+		}
 	}
 
 	return job

--- a/pkg/resources/update_job.go
+++ b/pkg/resources/update_job.go
@@ -103,6 +103,8 @@ func PrepareMattermostJobTemplate(name, namespace string, baseDeployment *appsv1
 	// Override values for job-specific behavior.
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	for i := range job.Spec.Template.Spec.Containers {
+		if job.Spec.Template.Spec.Containers[i].Name != "mattermost" { continue }
+		
 		job.Spec.Template.Spec.Containers[i].Command = []string{"mattermost", "version"}
 	}
 

--- a/pkg/resources/update_job.go
+++ b/pkg/resources/update_job.go
@@ -104,7 +104,7 @@ func PrepareMattermostJobTemplate(name, namespace string, baseDeployment *appsv1
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	for i := range job.Spec.Template.Spec.Containers {
 		if job.Spec.Template.Spec.Containers[i].Name == "mattermost" {
-			job.Spec.Template.Spec.Containers[i].Command = []string{"mattermost", "version"}
+			job.Spec.Template.Spec.Containers[i].Args = []string{"version"}
 		}
 	}
 


### PR DESCRIPTION
#### Summary

This will allow any supervisor/wrapper to be injected into mattermost via `resourcePatch` and keep expected behaviour.
This way, all parameters, wrappers that need to survive into update  job can be patched into `command` and those that do not can go into `args`

```release-note

```
